### PR TITLE
evobench-run wd: set `DATASET_DIR`, usability improvements, add `log` subcommand

### DIFF
--- a/evobench-evaluator/src/ask.rs
+++ b/evobench-evaluator/src/ask.rs
@@ -1,0 +1,27 @@
+use std::io::Write;
+use std::{
+    fs::OpenOptions,
+    io::{BufRead, BufReader},
+};
+
+use anyhow::{bail, Result};
+
+pub fn ask_yn(question: &str) -> Result<bool> {
+    let mut opts = OpenOptions::new();
+    opts.read(true).write(true).create(false);
+    let opn = || opts.open("/dev/tty");
+    let mut inp = BufReader::new(opn()?);
+    let mut outp = opn()?;
+    for n in (1..5).rev() {
+        write!(outp, "{} (y/n) ", question)?;
+        let mut ans = String::new();
+        inp.read_line(&mut ans)?;
+        if ans.len() > 1 && ans.starts_with("y") {
+            return Ok(true);
+        } else if ans.len() > 1 && ans.starts_with("n") {
+            return Ok(false);
+        }
+        writeln!(outp, "Please answer with y or n, {} tries left", n)?;
+    }
+    bail!("Could not get an answer to the question {:?}", question)
+}

--- a/evobench-evaluator/src/bin/evobench-run.rs
+++ b/evobench-evaluator/src/bin/evobench-run.rs
@@ -1063,8 +1063,8 @@ fn run() -> Result<Option<PathBuf>> {
             let check_original_status = |original_status: Status| -> Result<()> {
                 if original_status.can_be_used_for_jobs() {
                     bail!(
-                        "marking is meant for working directories in error status, \
-                         but this dir has status '{original_status}'"
+                        "this action is only for working directories in error status, \
+                         but this directory has status '{original_status}'"
                     )
                     // Also can't currently signal working dir status
                     // changes to the running daemon, only Error and

--- a/evobench-evaluator/src/bin/evobench-run.rs
+++ b/evobench-evaluator/src/bin/evobench-run.rs
@@ -1192,6 +1192,8 @@ fn run() -> Result<Option<PathBuf>> {
                         .get_working_directory(id)
                         .ok_or_else(&no_exist)?;
 
+                    check_original_status(working_directory.working_directory_status.status)?;
+
                     let (standard_log_path, _id) =
                         working_directory.last_standard_log_path()?.ok_or_else(|| {
                             anyhow!("could not find a log file for working directory {id}")

--- a/evobench-evaluator/src/bin/evobench-run.rs
+++ b/evobench-evaluator/src/bin/evobench-run.rs
@@ -1082,8 +1082,8 @@ fn run() -> Result<Option<PathBuf>> {
 
                         let show = match (active, error) {
                             (true, true) | (false, false) => true,
-                            (true, false) => !wd.working_directory_status.status.is_error(),
-                            (false, true) => wd.working_directory_status.status.is_error(),
+                            (true, false) => status.can_be_used_for_jobs(),
+                            (false, true) => !status.can_be_used_for_jobs(),
                         };
                         if show {
                             table.write_data_row(
@@ -1111,10 +1111,9 @@ fn run() -> Result<Option<PathBuf>> {
                     let now = SystemTime::now();
 
                     let mut cleanup_ids = Vec::new();
-                    for (id, wd) in working_directory_pool
-                        .all_entries()
-                        .filter(|(_, wd)| wd.working_directory_status.status.is_error())
-                    {
+                    for (id, wd) in working_directory_pool.all_entries().filter(|(_, wd)| {
+                        !wd.working_directory_status.status.can_be_used_for_jobs()
+                    }) {
                         let d = now.duration_since(wd.last_use).map_err(ctx!(
                             "calculating time since last use of working directory {id}"
                         ))?;

--- a/evobench-evaluator/src/bin/evobench-run.rs
+++ b/evobench-evaluator/src/bin/evobench-run.rs
@@ -1314,7 +1314,7 @@ fn run() -> Result<Option<PathBuf>> {
 
                     println!(
                         "The log file from this job execution is:\n\
-                                 {standard_log_path:?}\n"
+                         {standard_log_path:?}\n"
                     );
 
                     if shell != "bash" && shell != "/bin/bash" {

--- a/evobench-evaluator/src/bin/evobench-run.rs
+++ b/evobench-evaluator/src/bin/evobench-run.rs
@@ -1175,14 +1175,14 @@ fn run() -> Result<Option<PathBuf>> {
                         let mut lock = working_directory_pool.lock_mut()?;
                         for id in cleanup_ids {
                             if dry_run {
-                                println!("would delete working directory {id}");
+                                eprintln!("would delete working directory {id}");
                             } else {
                                 // XX Note: can this fail if a concurrent
                                 // instance deletes it in the mean time?
                                 lock.delete_working_directory(id)?;
-                                if verbose {
-                                    println!("{id}");
-                                }
+                            }
+                            if verbose {
+                                println!("{id}");
                             }
                         }
                     }

--- a/evobench-evaluator/src/bin/evobench-run.rs
+++ b/evobench-evaluator/src/bin/evobench-run.rs
@@ -1264,6 +1264,15 @@ fn run() -> Result<Option<PathBuf>> {
                                 bash_string_from_program_path_and_args(command, arguments)?
                             );
 
+                            let actual_commit =
+                                working_directory.git_working_dir.get_head_commit_id()?;
+                            if commit_id_str != actual_commit {
+                                println!(
+                                    "*** WARNING: the checked-out commit in this directory \
+                                     does not match the commit id for the job! ***\n"
+                                );
+                            }
+
                             // Enter dir without any locking (other
                             // than dir being in Status::Examination
                             // now), OK?

--- a/evobench-evaluator/src/bin/evobench-run.rs
+++ b/evobench-evaluator/src/bin/evobench-run.rs
@@ -1188,7 +1188,8 @@ fn run() -> Result<Option<PathBuf>> {
                             let shell = std::env::var_os("SHELL").unwrap_or("bash".into());
                             if shell != "bash" && shell != "/bin/bash" {
                                 println!(
-                                    "Note: SHELL is set to {shell:?}, but the following syntax is for bash.\n"
+                                    "Note: SHELL is set to {shell:?}, but the following syntax \
+                                     is for bash.\n"
                                 );
                             }
 

--- a/evobench-evaluator/src/bin/evobench-run.rs
+++ b/evobench-evaluator/src/bin/evobench-run.rs
@@ -67,7 +67,7 @@ use evobench_evaluator::{
 #[derive(clap::Parser, Debug)]
 #[clap(next_line_help = true)]
 #[clap(set_term_width = get_terminal_width(4))]
-/// Schedule (and query?) benchmarking jobs.
+/// Schedule and query benchmarking jobs.
 struct Opts {
     #[clap(flatten)]
     log_level: LogLevelOpt,
@@ -154,7 +154,8 @@ enum SubCommand {
         quiet_opt: QuietOpt,
     },
 
-    /// Insert jobs for new commits on configured branch names
+    /// Insert jobs for new commits on branch names configured in the
+    /// config option `remote_branch_names_for_poll`
     Poll {
         // No QuietOpt since that must be the default. Also, another
         // force option since the help text is different here.

--- a/evobench-evaluator/src/bin/evobench-run.rs
+++ b/evobench-evaluator/src/bin/evobench-run.rs
@@ -1306,6 +1306,10 @@ fn run() -> Result<Option<PathBuf>> {
                                 } else {
                                     // keep marked
                                 }
+                            } else {
+                                if !mark {
+                                    println!("Leaving working directory status as 'examination'");
+                                }
                             }
 
                             std::process::exit(status.to_exit_code());

--- a/evobench-evaluator/src/bin/evobench-run.rs
+++ b/evobench-evaluator/src/bin/evobench-run.rs
@@ -40,7 +40,7 @@ use evobench_evaluator::{
         insert_jobs::{insert_jobs, open_already_inserted, ForceOpt, QuietOpt},
         polling_pool::PollingPool,
         run_context::RunContext,
-        run_job::{DryRun, JobRunner},
+        run_job::JobRunner,
         run_queue::RunQueue,
         run_queues::RunQueues,
         versioned_dataset_dir::VersionedDatasetDir,
@@ -177,11 +177,6 @@ enum SubCommand {
     /// Run the existing jobs; this takes a lock or stops with an
     /// error if the lock is already taken
     Run {
-        /// Do not run the jobs, but still consume the queue
-        /// entries--XX partially removed, not working anymore?
-        #[clap(short, long, default_value = "DoAll")]
-        dry_run: DryRun,
-
         #[clap(subcommand)]
         mode: RunMode,
     },
@@ -325,7 +320,6 @@ fn run_queues(
     mut queues: RunQueues,
     working_directory_base_dir: WorkingDirectoryPoolBaseDir,
     mut working_directory_pool: WorkingDirectoryPool,
-    dry_run: DryRun,
     global_app_state_dir: &GlobalAppStateDir,
     once: bool,
     restart_on_upgrades: bool,
@@ -424,7 +418,6 @@ fn run_queues(
             JobRunner {
                 working_directory_pool: &mut working_directory_pool,
                 output_base_dir: &output_base_dir,
-                dry_run,
                 timestamp: DateTimeWithOffset::now(),
                 run_config,
                 versioned_dataset_dir: &versioned_dataset_dir,
@@ -986,7 +979,7 @@ fn run() -> Result<Option<PathBuf>> {
             }
         }
 
-        SubCommand::Run { dry_run, mode } => {
+        SubCommand::Run { mode } => {
             let run_lock_path = conf.run_jobs_lock_path(&global_app_state_dir);
             // Should StandaloneExclusiveFileLock have an option to
             // create itself?
@@ -1010,7 +1003,6 @@ fn run() -> Result<Option<PathBuf>> {
                         queues,
                         working_directory_base_dir,
                         working_directory_pool,
-                        dry_run,
                         &global_app_state_dir,
                         true,
                         false,
@@ -1036,7 +1028,6 @@ fn run() -> Result<Option<PathBuf>> {
                             queues,
                             working_directory_base_dir,
                             working_directory_pool,
-                            dry_run,
                             &global_app_state_dir,
                             false,
                             restart_on_upgrades,

--- a/evobench-evaluator/src/bin/evobench-run.rs
+++ b/evobench-evaluator/src/bin/evobench-run.rs
@@ -267,14 +267,14 @@ enum ExaminationAction {
     /// Mark the given working directories for examination, so that
     /// they are not deleted by `evobench-run wd cleanup`
     Mark {
-        /// Mark as 'error' status instead of 'examination'; use if
-        /// done with examination and want cronjob based auto-deletion
-        /// (via `evobench-run wd cleanup stale-for-days`) to take
-        /// care of it.
-        #[clap(long)]
-        error: bool,
-
         /// The IDs of the working direcories to mark
+        ids: Vec<WorkingDirectoryId>,
+    },
+    /// Change the status of the given working directories back to
+    /// "error", so that they are again deleted by `evobench-run wd
+    /// cleanup`
+    Unmark {
+        /// The IDs of the working direcories to unmark
         ids: Vec<WorkingDirectoryId>,
     },
     /// Mark the given working directory for examination, then open a
@@ -1166,14 +1166,16 @@ fn run() -> Result<Option<PathBuf>> {
                     };
 
                     match mode {
-                        ExaminationAction::Mark { error, ids } => {
-                            let wanted_status = if error {
-                                Status::Error
-                            } else {
-                                Status::Examination
-                            };
+                        ExaminationAction::Mark { ids } => {
                             for id in ids {
-                                if do_mark(wanted_status, id)?.is_none() {
+                                if do_mark(Status::Examination, id)?.is_none() {
+                                    warn!("there is no working directory for id {id}");
+                                }
+                            }
+                        }
+                        ExaminationAction::Unmark { ids } => {
+                            for id in ids {
+                                if do_mark(Status::Error, id)?.is_none() {
                                     warn!("there is no working directory for id {id}");
                                 }
                             }

--- a/evobench-evaluator/src/bin/evobench-run.rs
+++ b/evobench-evaluator/src/bin/evobench-run.rs
@@ -313,7 +313,7 @@ enum WdSubCommandCleanupMode {
     /// days ago
     StaleForDays {
         /// Number of days
-        n: u16,
+        x: f32,
     },
 }
 
@@ -1166,10 +1166,17 @@ fn run() -> Result<Option<PathBuf>> {
                     mode,
                 } => {
                     let stale_days = match mode {
-                        WdSubCommandCleanupMode::All => 0,
-                        WdSubCommandCleanupMode::StaleForDays { n } => n,
+                        WdSubCommandCleanupMode::All => 0.,
+                        WdSubCommandCleanupMode::StaleForDays { x } => x,
                     };
-                    let stale_seconds = u64::from(stale_days) * 24 * 3600;
+                    if stale_days < 0. {
+                        bail!("number of days must be non-negative");
+                    }
+                    if stale_days > 1000. || stale_days.is_nan() {
+                        bail!("number of days must be reasonable");
+                    }
+
+                    let stale_seconds = (stale_days * 24. * 3600.) as u64;
 
                     let now = SystemTime::now();
 

--- a/evobench-evaluator/src/bin/evobench-run.rs
+++ b/evobench-evaluator/src/bin/evobench-run.rs
@@ -1312,12 +1312,12 @@ fn run() -> Result<Option<PathBuf>> {
                                         working_directory.set_and_save_status(wanted_status)?;
                                         println!("Changed status to '{wanted_status}'");
                                     } else {
-                                        println!("Leaving status as 'examination'");
+                                        println!("Leaving status at 'examination'");
                                     }
                                 }
                             } else {
                                 if !mark {
-                                    println!("Leaving working directory status as 'examination'");
+                                    println!("Leaving working directory status at 'examination'");
                                 }
                             }
 

--- a/evobench-evaluator/src/bin/evobench-run.rs
+++ b/evobench-evaluator/src/bin/evobench-run.rs
@@ -1279,7 +1279,9 @@ fn run() -> Result<Option<PathBuf>> {
                             let status = cmd.status()?;
 
                             if unmark || original_status != Status::Examination {
-                                if !mark {
+                                if mark {
+                                    // keep marked
+                                } else {
                                     let do_revert = unmark
                                         || ask_yn(&format!(
                                             "Should the working directory status be reverted to \
@@ -1303,8 +1305,6 @@ fn run() -> Result<Option<PathBuf>> {
                                     } else {
                                         println!("Leaving status as 'examination'");
                                     }
-                                } else {
-                                    // keep marked
                                 }
                             } else {
                                 if !mark {

--- a/evobench-evaluator/src/bin/evobench-run.rs
+++ b/evobench-evaluator/src/bin/evobench-run.rs
@@ -1259,8 +1259,9 @@ fn run() -> Result<Option<PathBuf>> {
                                 "The following environment variables have been set:\n\n{exports}"
                             );
                             println!(
-                                "Please set `BENCH_OUTPUT_LOG` and optionally `EVOBENCH_LOG`, \
-                                 then run the following to execute the benchmarking:\n\n  {}\n",
+                                "To rerun the benchmarking, please set `BENCH_OUTPUT_LOG` \
+                                 and optionally `EVOBENCH_LOG` to some suitable paths, \
+                                 then run:\n\n  {}\n",
                                 bash_string_from_program_path_and_args(command, arguments)?
                             );
 

--- a/evobench-evaluator/src/bin/evobench-run.rs
+++ b/evobench-evaluator/src/bin/evobench-run.rs
@@ -1278,7 +1278,7 @@ fn run() -> Result<Option<PathBuf>> {
                                     let do_revert = unmark
                                         || ask_yn(&format!(
                                             "Should the working directory status be reverted to \
-                                         '{original_status}' (i.e. are you done)?"
+                                             '{original_status}' (i.e. are you done)?"
                                         ))?;
 
                                     if do_revert {
@@ -1293,6 +1293,8 @@ fn run() -> Result<Option<PathBuf>> {
                                     } else {
                                         println!("Leaving status as 'examination'");
                                     }
+                                } else {
+                                    // keep marked
                                 }
                             }
 

--- a/evobench-evaluator/src/bin/evobench-run.rs
+++ b/evobench-evaluator/src/bin/evobench-run.rs
@@ -241,6 +241,10 @@ enum WdSubCommand {
         /// Show the working directories that have been set aside due to errors
         #[clap(long)]
         error: bool,
+
+        /// Sort the list by the `last_used` timestamp
+        #[clap(short, long)]
+        sort_used: bool,
     },
     /// Delete working directories that have been set aside due to
     /// errors
@@ -1086,6 +1090,7 @@ fn run() -> Result<Option<PathBuf>> {
                     terminal_table_opts,
                     active,
                     error,
+                    sort_used,
                 } => {
                     let titles = &["id", "status", "num_runs", "creation_timestamp", "last_use"]
                         .map(|s| TerminalTableTitle {
@@ -1101,7 +1106,13 @@ fn run() -> Result<Option<PathBuf>> {
                         stdout().lock(),
                     )?;
 
-                    for (id, wd) in working_directory_pool.all_entries() {
+                    let mut all_entries: Vec<_> = working_directory_pool.all_entries().collect();
+
+                    if sort_used {
+                        all_entries.sort_by(|a, b| a.1.last_use.cmp(&b.1.last_use))
+                    }
+
+                    for (id, wd) in &all_entries {
                         let WorkingDirectoryStatus {
                             creation_timestamp,
                             num_runs,

--- a/evobench-evaluator/src/bin/evobench-run.rs
+++ b/evobench-evaluator/src/bin/evobench-run.rs
@@ -1193,12 +1193,12 @@ fn run() -> Result<Option<PathBuf>> {
                                 .get_working_directory(id)
                                 .ok_or_else(&no_exist)?;
 
-                            let (path, _id) =
+                            let (standard_log_path, _id) =
                                 working_directory.last_standard_log_path()?.ok_or_else(|| {
                                     anyhow!("could not find a log file for working directory {id}")
                                 })?;
 
-                            let command_log_file = CommandLogFile::from(&path);
+                            let command_log_file = CommandLogFile::from(&standard_log_path);
                             let command_log = command_log_file.command_log()?;
 
                             let BenchmarkingJobParameters {
@@ -1248,6 +1248,14 @@ fn run() -> Result<Option<PathBuf>> {
                                 .join("");
 
                             let shell = std::env::var_os("SHELL").unwrap_or("bash".into());
+
+                            // -- Print explanations ----
+
+                            println!(
+                                "The log file from this job execution is:\n\
+                                 {standard_log_path:?}\n"
+                            );
+
                             if shell != "bash" && shell != "/bin/bash" {
                                 println!(
                                     "Note: SHELL is set to {shell:?}, but the following syntax \
@@ -1258,6 +1266,7 @@ fn run() -> Result<Option<PathBuf>> {
                             println!(
                                 "The following environment variables have been set:\n\n{exports}"
                             );
+
                             println!(
                                 "To rerun the benchmarking, please set `BENCH_OUTPUT_LOG` \
                                  and optionally `EVOBENCH_LOG` to some suitable paths, \

--- a/evobench-evaluator/src/bin/evobench-run.rs
+++ b/evobench-evaluator/src/bin/evobench-run.rs
@@ -10,7 +10,6 @@ use std::{
     ffi::OsStr,
     fmt::Display,
     io::{stdout, IsTerminal, Write},
-    os::unix::process::ExitStatusExt,
     path::PathBuf,
     process::{exit, Command},
     str::FromStr,
@@ -60,6 +59,7 @@ use evobench_evaluator::{
         arc::CloneArc,
         logging::{set_log_level, LogLevelOpt},
         re_exec::re_exec_with_existing_args_and_env,
+        unix::ToExitCode,
     },
     warn,
 };
@@ -1296,16 +1296,7 @@ fn run() -> Result<Option<PathBuf>> {
                                 }
                             }
 
-                            // XX I do have this somewhere, right?
-                            let exitcode = if status.success() {
-                                0
-                            } else {
-                                status
-                                    .code()
-                                    .or_else(|| status.signal().map(|x| x + 128))
-                                    .unwrap_or(255)
-                            };
-                            std::process::exit(exitcode);
+                            std::process::exit(status.to_exit_code());
                         }
                     }
                 }

--- a/evobench-evaluator/src/bin/evobench-run.rs
+++ b/evobench-evaluator/src/bin/evobench-run.rs
@@ -271,7 +271,7 @@ enum ExaminationAction {
         /// The IDs of the working direcories to mark
         ids: Vec<WorkingDirectoryId>,
     },
-    /// Mark the given working directories for examination, then open
+    /// Mark the given working directory for examination, then open
     /// a shell inside it. The shell in the `SHELL` environment
     /// variable is used, falling back to "bash".
     Enter {

--- a/evobench-evaluator/src/bin/evobench-run.rs
+++ b/evobench-evaluator/src/bin/evobench-run.rs
@@ -1150,9 +1150,10 @@ fn run() -> Result<Option<PathBuf>> {
                     let now = SystemTime::now();
 
                     let mut cleanup_ids = Vec::new();
-                    for (id, wd) in working_directory_pool.all_entries().filter(|(_, wd)| {
-                        !wd.working_directory_status.status.can_be_used_for_jobs()
-                    }) {
+                    for (id, wd) in working_directory_pool
+                        .all_entries()
+                        .filter(|(_, wd)| wd.working_directory_status.status == Status::Error)
+                    {
                         let d = now.duration_since(wd.last_use).map_err(ctx!(
                             "calculating time since last use of working directory {id}"
                         ))?;

--- a/evobench-evaluator/src/bin/evobench-util.rs
+++ b/evobench-evaluator/src/bin/evobench-util.rs
@@ -70,10 +70,10 @@ enum SubCommand {
         #[clap(long, short)]
         params: Option<String>,
 
-        /// The regex to match a log lie that starts a timed region
+        /// The regex to match a log line that starts a timed region
         regex_start: String,
 
-        /// The regex to match a log lie that ends a timed region
+        /// The regex to match a log line that ends a timed region
         regex_end: String,
 
         /// Override the path to the config file (default: the paths

--- a/evobench-evaluator/src/bin/evobench-util.rs
+++ b/evobench-evaluator/src/bin/evobench-util.rs
@@ -66,7 +66,8 @@ enum SubCommand {
         /// variables that are provided. NOTE: does not verify correct
         /// syntax of the variable names and values (currently no
         /// configuration is read, thus the info is not available)
-        /// except for the basic acceptance for custom env var names.
+        /// except for the basic acceptance rules for custom env var
+        /// names.
         #[clap(long, short)]
         params: Option<String>,
 

--- a/evobench-evaluator/src/key.rs
+++ b/evobench-evaluator/src/key.rs
@@ -40,7 +40,7 @@ use crate::{
     run::{
         config::BenchmarkingCommand,
         custom_parameter::{AllowedCustomParameter, CustomParameterValue},
-        run_job::AllowableCustomEnvVar,
+        env_vars::AllowableCustomEnvVar,
     },
     serde::allowed_env_var::AllowedEnvVar,
 };

--- a/evobench-evaluator/src/lib.rs
+++ b/evobench-evaluator/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod ask;
 pub mod config_file;
 pub mod crypto_hash;
 pub mod ctx;

--- a/evobench-evaluator/src/run/config.rs
+++ b/evobench-evaluator/src/run/config.rs
@@ -16,6 +16,7 @@ use crate::{
     info,
     io_utils::{bash::bash_string_from_cmd, div::create_dir_if_not_exists},
     key::CustomParameters,
+    run::env_vars::AllowableCustomEnvVar,
     serde::{
         allowed_env_var::AllowedEnvVar,
         date_and_time::LocalNaiveTime,
@@ -33,8 +34,7 @@ use crate::{
 
 use super::{
     benchmarking_job::BenchmarkingJobSettingsOpts, custom_parameter::AllowedCustomParameter,
-    global_app_state_dir::GlobalAppStateDir, run_job::AllowableCustomEnvVar,
-    working_directory_pool::WorkingDirectoryPoolOpts,
+    global_app_state_dir::GlobalAppStateDir, working_directory_pool::WorkingDirectoryPoolOpts,
 };
 
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]

--- a/evobench-evaluator/src/run/custom_parameter.rs
+++ b/evobench-evaluator/src/run/custom_parameter.rs
@@ -47,6 +47,10 @@ impl CustomParameterValue {
         &self.value
     }
 
+    pub fn r#type(&self) -> CustomParameterType {
+        self.r#type
+    }
+
     pub fn checked_from(r#type: CustomParameterType, value: &KString) -> Result<Self> {
         // Check:
         match r#type {

--- a/evobench-evaluator/src/run/custom_parameter.rs
+++ b/evobench-evaluator/src/run/custom_parameter.rs
@@ -3,11 +3,13 @@ use std::{ffi::OsStr, num::NonZeroU32, str::FromStr};
 use anyhow::{anyhow, bail, Result};
 use kstring::KString;
 
-use crate::serde::{
-    allowed_env_var::AllowEnvVar, proper_dirname::ProperDirname, proper_filename::ProperFilename,
+use crate::{
+    run::env_vars::AllowableCustomEnvVar,
+    serde::{
+        allowed_env_var::AllowEnvVar, proper_dirname::ProperDirname,
+        proper_filename::ProperFilename,
+    },
 };
-
-use super::run_job::AllowableCustomEnvVar;
 
 /// The value type of a custom parameter--those values are passed as
 /// environment variables and hence as strings, but they are parsed

--- a/evobench-evaluator/src/run/dataset_dir_env_var.rs
+++ b/evobench-evaluator/src/run/dataset_dir_env_var.rs
@@ -1,0 +1,43 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+use run_git::git::GitWorkingDir;
+
+use crate::{git::GitHash, key::CustomParameters, run::versioned_dataset_dir::VersionedDatasetDir};
+
+macro_rules! try_ok {
+    { $e:expr } =>  {
+        match $e {
+            Some(v) => v,
+            None => return Ok(None)
+        }
+    }
+}
+
+/// Find the matching dataset if both the
+/// `versioned_datasets_base_dir` config and the `DATASET` custom
+/// parameter values are provided.
+pub fn dataset_dir_for(
+    // If those two are given:
+    versioned_datasets_base_dir: Option<&Path>,
+    custom_parameters: &CustomParameters,
+    // then calculate the result using them and those:
+    versioned_dataset_dir: &VersionedDatasetDir,
+    git_working_dir: &GitWorkingDir,
+    commit_id: &GitHash,
+) -> Result<Option<PathBuf>> {
+    let versioned_datasets_base_dir = try_ok!(versioned_datasets_base_dir);
+
+    let dataset_name = try_ok!(custom_parameters
+        .btree_map()
+        .get(&"DATASET".parse().expect("fits requirements")));
+    // ^ XX hmm, check that the type of the custom env var
+    // is a directory name?
+
+    let vdirlock = versioned_dataset_dir.updated_git_graph(git_working_dir, commit_id)?;
+
+    Ok(Some(vdirlock.dataset_dir_for_commit(
+        versioned_datasets_base_dir,
+        dataset_name.as_str(),
+    )?))
+}

--- a/evobench-evaluator/src/run/env_vars.rs
+++ b/evobench-evaluator/src/run/env_vars.rs
@@ -1,0 +1,95 @@
+use crate::serde::allowed_env_var::AllowEnvVar;
+
+pub const EVOBENCH_ENV_VARS: &[&str] = &[
+    "EVOBENCH_LOG",
+    "BENCH_OUTPUT_LOG",
+    "COMMIT_ID",
+    "DATASET_DIR",
+];
+
+pub fn is_evobench_env_var(s: &str) -> bool {
+    EVOBENCH_ENV_VARS.contains(&s)
+}
+
+/// A parameter for `AllowedEnvVar` that checks that the variable is
+/// not going to conflict with one of the built-in evobench env vars
+/// (in the future perhaps also check for things like USER?)
+#[derive(Debug)]
+pub struct AllowableCustomEnvVar;
+impl AllowEnvVar for AllowableCustomEnvVar {
+    const MAX_ENV_VAR_NAME_LEN: usize = 80;
+
+    fn allow_env_var(s: &str) -> bool {
+        !is_evobench_env_var(s)
+    }
+
+    fn expecting() -> String {
+        format!(
+            "a variable name that is *not* any of {}",
+            EVOBENCH_ENV_VARS.join(", ")
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use crate::serde::allowed_env_var::AllowedEnvVar;
+
+    use super::*;
+
+    #[test]
+    fn t_allowable_custom_env_var_name() {
+        let allow = AllowableCustomEnvVar::allow_env_var;
+        assert!(allow("FOO"));
+        // We don't care whether the user decides to use unorthodox
+        // variable names
+        assert!(allow("foo"));
+        assert!(allow("%&/',é\nhmm"));
+        assert!(allow(
+            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        ));
+        // Too long, but have to rely on `AllowedEnvVar` to get the
+        // `MAX_ENV_VAR_NAME_LEN` constant checked
+        assert!(allow(
+            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        ));
+
+        let allow =
+            |s: &str| -> bool { AllowedEnvVar::<AllowableCustomEnvVar>::from_str(s).is_ok() };
+
+        assert!(allow("foo"));
+        assert!(allow("%&/',é\nhmm"));
+        assert!(allow(
+            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        ));
+
+        // Problems caughtby `AllowedEnvVar::from_str`
+        assert!(!allow(
+            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        ));
+        assert!(!allow("A\0B"));
+        assert!(!allow("foo=bar"));
+        assert!(!allow("EVOBENCH_LOG"));
+
+        assert_eq!(
+            AllowedEnvVar::<AllowableCustomEnvVar>::from_str("EVOBENCH_LOG")
+                .err()
+                .unwrap()
+                .to_string(),
+            "AllowableCustomEnvVar env variable \"EVOBENCH_LOG\" is reserved, expecting a variable name \
+             that is *not* any of EVOBENCH_LOG, BENCH_OUTPUT_LOG, COMMIT_ID, DATASET_DIR"
+        );
+    }
+}
+
+// Can't make this const easily, but doesn't matter. It'll catch bugs
+// on the first job run.
+pub fn assert_evobench_env_var(s: &str) -> &str {
+    if is_evobench_env_var(s) {
+        s
+    } else {
+        panic!("Not a known EVOBENCH_ENV_VARS entry: {s:?}")
+    }
+}

--- a/evobench-evaluator/src/run/mod.rs
+++ b/evobench-evaluator/src/run/mod.rs
@@ -2,6 +2,7 @@ pub mod benchmarking_job;
 pub mod command_log_file;
 pub mod config;
 pub mod custom_parameter;
+pub mod env_vars;
 pub mod global_app_state_dir;
 pub mod insert_jobs;
 pub mod migrate;

--- a/evobench-evaluator/src/run/mod.rs
+++ b/evobench-evaluator/src/run/mod.rs
@@ -2,6 +2,7 @@ pub mod benchmarking_job;
 pub mod command_log_file;
 pub mod config;
 pub mod custom_parameter;
+pub mod dataset_dir_env_var;
 pub mod env_vars;
 pub mod global_app_state_dir;
 pub mod insert_jobs;

--- a/evobench-evaluator/src/run/output_directory_structure.rs
+++ b/evobench-evaluator/src/run/output_directory_structure.rs
@@ -15,7 +15,7 @@ use crate::{
     ctx,
     git::GitHash,
     key::RunParameters,
-    run::run_job::AllowableCustomEnvVar,
+    run::env_vars::AllowableCustomEnvVar,
     serde::{
         allowed_env_var::AllowedEnvVar, date_and_time::DateTimeWithOffset,
         proper_dirname::ProperDirname, proper_filename::ProperFilename,

--- a/evobench-evaluator/src/run/run_job.rs
+++ b/evobench-evaluator/src/run/run_job.rs
@@ -26,14 +26,11 @@ use crate::{
     key::{BenchmarkingJobParameters, RunParameters},
     path_util::rename_tmp_path,
     run::{
-        benchmarking_job::BenchmarkingJob, config::RunConfig, output_directory_structure::KeyDir,
-        post_process::compress_file_as, run_queues::RunQueuesData,
-        versioned_dataset_dir::VersionedDatasetDir,
+        benchmarking_job::BenchmarkingJob, config::RunConfig, env_vars::assert_evobench_env_var,
+        output_directory_structure::KeyDir, post_process::compress_file_as,
+        run_queues::RunQueuesData, versioned_dataset_dir::VersionedDatasetDir,
     },
-    serde::{
-        allowed_env_var::AllowEnvVar, date_and_time::DateTimeWithOffset,
-        proper_dirname::ProperDirname,
-    },
+    serde::{date_and_time::DateTimeWithOffset, proper_dirname::ProperDirname},
     utillib::logging::{log_level, LogLevel},
 };
 
@@ -41,102 +38,6 @@ use super::{
     config::{BenchmarkingCommand, ScheduleCondition},
     working_directory_pool::{WorkingDirectoryId, WorkingDirectoryPool},
 };
-
-// ------------------------------------------------------------------
-pub const EVOBENCH_ENV_VARS: &[&str] = &[
-    "EVOBENCH_LOG",
-    "BENCH_OUTPUT_LOG",
-    "COMMIT_ID",
-    "DATASET_DIR",
-];
-
-pub fn is_evobench_env_var(s: &str) -> bool {
-    EVOBENCH_ENV_VARS.contains(&s)
-}
-
-/// A parameter for `AllowedEnvVar` that checks that the variable is
-/// not going to conflict with one of the built-in evobench env vars
-/// (in the future perhaps also check for things like USER?)
-#[derive(Debug)]
-pub struct AllowableCustomEnvVar;
-impl AllowEnvVar for AllowableCustomEnvVar {
-    const MAX_ENV_VAR_NAME_LEN: usize = 80;
-
-    fn allow_env_var(s: &str) -> bool {
-        !is_evobench_env_var(s)
-    }
-
-    fn expecting() -> String {
-        format!(
-            "a variable name that is *not* any of {}",
-            EVOBENCH_ENV_VARS.join(", ")
-        )
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::str::FromStr;
-
-    use crate::serde::allowed_env_var::AllowedEnvVar;
-
-    use super::*;
-
-    #[test]
-    fn t_allowable_custom_env_var_name() {
-        let allow = AllowableCustomEnvVar::allow_env_var;
-        assert!(allow("FOO"));
-        // We don't care whether the user decides to use unorthodox
-        // variable names
-        assert!(allow("foo"));
-        assert!(allow("%&/',é\nhmm"));
-        assert!(allow(
-            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        ));
-        // Too long, but have to rely on `AllowedEnvVar` to get the
-        // `MAX_ENV_VAR_NAME_LEN` constant checked
-        assert!(allow(
-            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        ));
-
-        let allow =
-            |s: &str| -> bool { AllowedEnvVar::<AllowableCustomEnvVar>::from_str(s).is_ok() };
-
-        assert!(allow("foo"));
-        assert!(allow("%&/',é\nhmm"));
-        assert!(allow(
-            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        ));
-
-        // Problems caughtby `AllowedEnvVar::from_str`
-        assert!(!allow(
-            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        ));
-        assert!(!allow("A\0B"));
-        assert!(!allow("foo=bar"));
-        assert!(!allow("EVOBENCH_LOG"));
-
-        assert_eq!(
-            AllowedEnvVar::<AllowableCustomEnvVar>::from_str("EVOBENCH_LOG")
-                .err()
-                .unwrap()
-                .to_string(),
-            "AllowableCustomEnvVar env variable \"EVOBENCH_LOG\" is reserved, expecting a variable name \
-             that is *not* any of EVOBENCH_LOG, BENCH_OUTPUT_LOG, COMMIT_ID, DATASET_DIR"
-        );
-    }
-}
-
-// Can't make this const easily, but doesn't matter. It'll catch bugs
-// on the first job run.
-fn assert_evobench_env_var(s: &str) -> &str {
-    if is_evobench_env_var(s) {
-        s
-    } else {
-        panic!("Not a known EVOBENCH_ENV_VARS entry: {s:?}")
-    }
-}
-// ------------------------------------------------------------------
 
 #[derive(Debug, EnumString, PartialEq, Clone, Copy)]
 #[repr(u8)]

--- a/evobench-evaluator/src/run/run_job.rs
+++ b/evobench-evaluator/src/run/run_job.rs
@@ -30,18 +30,16 @@ use crate::{
         run_queues::RunQueuesData, versioned_dataset_dir::VersionedDatasetDir,
     },
     serde::{date_and_time::DateTimeWithOffset, proper_dirname::ProperDirname},
-    utillib::logging::{log_level, LogLevel},
+    utillib::{
+        logging::{log_level, LogLevel},
+        user::get_username,
+    },
 };
 
 use super::{
     config::{BenchmarkingCommand, ScheduleCondition},
     working_directory_pool::{WorkingDirectoryId, WorkingDirectoryPool},
 };
-
-// I am tired
-fn get_username() -> Result<String> {
-    std::env::var("USER").map_err(ctx!("can't get USER environment variable"))
-}
 
 /// Returns the path to a temporary directory, creating it if
 /// necessary and checking ownership if it already exists. The

--- a/evobench-evaluator/src/run/working_directory.rs
+++ b/evobench-evaluator/src/run/working_directory.rs
@@ -235,7 +235,7 @@ impl WorkingDirectory {
     /// Originally thought `id` is a pool matter only, but now need it
     /// to filter for standard_log paths. Leaving id as string,
     /// though.)
-    fn parent_path_and_id(&self) -> Result<(&Path, &str)> {
+    pub fn parent_path_and_id(&self) -> Result<(&Path, &str)> {
         let p = self.git_working_dir.working_dir_path_ref();
         let parent = p
             .parent()

--- a/evobench-evaluator/src/util/grep_diff.rs
+++ b/evobench-evaluator/src/util/grep_diff.rs
@@ -13,7 +13,7 @@ use crate::{
     key::{BenchmarkingJobParameters, RunParameters},
     run::{
         command_log_file::{CommandLog, CommandLogFile, ParseCommandLogError},
-        run_job::AllowableCustomEnvVar,
+        env_vars::AllowableCustomEnvVar,
     },
     serde::{
         allowed_env_var::AllowedEnvVar, proper_dirname::ProperDirname,

--- a/evobench-evaluator/src/utillib/home.rs
+++ b/evobench-evaluator/src/utillib/home.rs
@@ -6,7 +6,7 @@ use lazy_static::lazy_static;
 pub enum HomeError {
     #[error(
         "path given in HOME environment variable does not point to \
-             an existing directory: {0:?}"
+         an existing directory: {0:?}"
     )]
     NotExist(PathBuf),
     #[error("HOME environment variable is not set")]

--- a/evobench-evaluator/src/utillib/mod.rs
+++ b/evobench-evaluator/src/utillib/mod.rs
@@ -8,3 +8,4 @@ pub mod re_exec;
 pub mod ref_or_owned;
 pub mod slice_or_box;
 pub mod type_name_short;
+pub mod user;

--- a/evobench-evaluator/src/utillib/mod.rs
+++ b/evobench-evaluator/src/utillib/mod.rs
@@ -8,4 +8,5 @@ pub mod re_exec;
 pub mod ref_or_owned;
 pub mod slice_or_box;
 pub mod type_name_short;
+pub mod unix;
 pub mod user;

--- a/evobench-evaluator/src/utillib/unix.rs
+++ b/evobench-evaluator/src/utillib/unix.rs
@@ -1,0 +1,19 @@
+// XX I already did something like this somewhere, right?
+
+use std::{os::unix::process::ExitStatusExt, process::ExitStatus};
+
+pub trait ToExitCode {
+    fn to_exit_code(&self) -> i32;
+}
+
+impl ToExitCode for ExitStatus {
+    fn to_exit_code(&self) -> i32 {
+        if self.success() {
+            0
+        } else {
+            self.code()
+                .or_else(|| self.signal().map(|x| x + 128))
+                .unwrap_or(255)
+        }
+    }
+}

--- a/evobench-evaluator/src/utillib/user.rs
+++ b/evobench-evaluator/src/utillib/user.rs
@@ -1,0 +1,8 @@
+use anyhow::Result;
+
+use crate::ctx;
+
+// ~once again
+pub fn get_username() -> Result<String> {
+    std::env::var("USER").map_err(ctx!("can't get USER environment variable"))
+}


### PR DESCRIPTION
Highlevel change list:

* The `wd examine *` sub sub commands have been moved to directly `wd *` (e.g. `evobench-run wd examine enter 123` becomes `evobench-run wd enter 123`)
* Add `wd unmark` subcommand to change a working dir in examination back to deletable
* `wd enter` now sets the special `DATASET_DIR` non-custom 'custom variable', was forgotten, remains hacky (and should probably really have solved it via providing a utility to the target app instead!)
* `wd list` got some more options
* Add `wd log 123` subcommand
* Show the log path on `wd enter 123`
* `wd cleanup stale-for-days` now takes floating point numbers as number of days
* `wd enter` now restores working directory status upon exit

List of all commits that are user-visible:

    evobench-run wd examine enter: restore status, add options for it
    evobench-run wd examine: check that the status is OK to mark or enter dir
    run/dataset_dir_env_var.rs: verify that the configuration describes a directory
    evobench-run wd examine enter: fix: set `DATASET_DIR`
    evobench-run wd examine: change from `mark --unmark` to `unmark`
    evobench-run wd examine enter --unmark: always act
    evobench-run wd examine enter: say when leaving marked
    evobench-run wd examine enter: warn if the checked-out commit does not match
    evobench-run wd examine enter: show the standard-log path
    evobench-run wd examine: add `log` subcommand
    evobench-run wd: merge subcommands of subcommand `examine` into upper level
    evobench-run wd list: add --sort-used
    evobench-run wd cleanup: add --dry-run
    evobench-run wd log: require that the working dir is in an error status
    evobench-run wd list: add --id-only
    evobench-run wd cleanup stale-for-days: make days floating point
